### PR TITLE
call as function

### DIFF
--- a/README.md
+++ b/README.md
@@ -583,7 +583,7 @@ from fastai.vision.models.unet import DynamicUnet
 ```python
 def build_res_unet(n_input=1, n_output=2, size=256):
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    body = create_body(resnet18, pretrained=True, n_in=n_input, cut=-2)
+    body = create_body(resnet18(), pretrained=True, n_in=n_input, cut=-2)
     net_G = DynamicUnet(body, n_output, (size, size)).to(device)
     return net_G
 ```


### PR DESCRIPTION
otherwise generates an error - "AttributeError: 'function' object has no attribute 'named_parameters'" 

hence call model as a function